### PR TITLE
Fix: remove exploit surrounding vesting

### DIFF
--- a/contracts/yGift/yGift.sol
+++ b/contracts/yGift/yGift.sol
@@ -129,7 +129,7 @@ contract yGift is ERC721("yearn Gift NFT", "yGIFT") {
 		_amount = min(_amount, _available);
 		uint _tips = min(_amount, gift.tipped);
 		gift.tipped = gift.tipped.sub(_tips);
-		gift.amount = gift.amount.add(_tips).sub(_amount);
+		gift.amount = gift.amount.add(_tips);
 		gift.amountWithdrawn = gift.amountWithdrawn.add(_amount);
 
 		IERC20(gift.token).safeTransfer(msg.sender, _amount);


### PR DESCRIPTION
As the initial amount nor the amount withdrawn is recorded, the amount available to be withdrawn is not calculated correctly.
It should be calculated as `initialAmount * min(block.timestamp - start, _duration) / duration - amountWithdrawn` but is calculated as `amount * min(block.timestamp - start, _duration) / duration` where amount is the amount of tokens not withdrawn yet. 
Because of this incorrect calculation one can withdraw the same percentage of the gift again and again until only a miniscule amount is left before the end of the vesting period. 